### PR TITLE
passing pid for shutdown & test maintenance metric

### DIFF
--- a/src/commands/client.rs
+++ b/src/commands/client.rs
@@ -57,10 +57,17 @@ impl CommandClient {
     }
 
     /// Initiatiate or cancel maintenance shutdown
-    pub async fn maintenance_shutdown(&self, minimum_length: Option<u64>) -> Result<()> {
+    pub async fn maintenance_shutdown(
+        &self,
+        minimum_length: Option<u64>,
+        shutdown_at: Option<u64>,
+    ) -> Result<()> {
         let url = hyperlocal::Uri::new(&self.socket_path, "/maintainance_shutdown");
 
-        let body = serde_json::to_string(&MaintenanceShutdown { minimum_length })?;
+        let body = serde_json::to_string(&MaintenanceShutdown {
+            minimum_length,
+            shutdown_at,
+        })?;
         let req = Request::builder()
             .method(Method::POST)
             .uri(url)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,13 +6,19 @@ mod server;
 
 use serde::{Deserialize, Serialize};
 
+use clap::Parser;
 pub use client::CommandClient;
 pub use server::spawn_control_server;
 
-#[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
+#[derive(Parser, PartialEq, Serialize, Deserialize, Debug, Clone)]
 struct MaintenanceShutdown {
     /// Specify the minimum length in blockheight for the maintenance shutdown
     minimum_length: Option<u64>,
+
+    /// Specify the block height to shutdown at, and will not check on it in maintenance window or
+    /// not.
+    #[arg(long)]
+    shutdown_at: Option<u64>,
 }
 
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -115,7 +115,7 @@ impl CommandServer {
     ) -> hyper::Result<Response<Body>> {
         let (tx, mut rx) = mpsc::channel(1);
         let args: MaintenanceShutdown = ok_or_500!(json_request(req).await);
-        let req = ipc::Request::MaintenanceShutdown(args.minimum_length, tx);
+        let req = ipc::Request::MaintenanceShutdown(args.minimum_length, args.shutdown_at, tx);
 
         if let Err(e) = self.supervisor_request_chan.send(req).await {
             return Ok(server_error(format!(

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -14,7 +14,12 @@ pub struct MaintenanceShutdownResponse {
 
 /// Request to send to the supervisor
 pub enum Request {
-    /// Schedule maintenance shutdown for a maintainace window of given size
+    /// Schedule maintenance shutdown for a maintainace window of given size or book a block
+    /// height to shutdown at
     /// + Channel where the supervisor will respond to once the request is finished
-    MaintenanceShutdown(Option<u64>, mpsc::Sender<MaintenanceShutdownResponse>),
+    MaintenanceShutdown(
+        Option<u64>,
+        Option<u64>,
+        mpsc::Sender<MaintenanceShutdownResponse>,
+    ),
 }

--- a/tests/test_maintenance_shutdown.py
+++ b/tests/test_maintenance_shutdown.py
@@ -115,24 +115,6 @@ def test_maintenance_shutdown(
         else:
             assert new_pid is not pid
 
-        # TODO check metric in other test, this will fail if the leader restart really quick
-        # for i in range(15):
-        #     time.sleep(1)
-        #     try:
-        #         res = leader.neard_metrics()
-        #         if (
-        #             res.get("near_block_expected_shutdown") is not None
-        #             or res.get("near_dynamic_config_changes") is not None
-        #         ):
-        #             break
-        #     except ConnectionRefusedError:
-        #         continue
-        # else:
-        #     assert (
-        #         res.get("near_block_expected_shutdown") is not None
-        #         or res.get("near_dynamic_config_changes") is not None
-        #     )
-
         note("checking on leader restart and keep producing block")
         check = 0
         while not leader.check_blocking():

--- a/tests/test_maintenance_shutdown.py
+++ b/tests/test_maintenance_shutdown.py
@@ -25,7 +25,7 @@ def work_with_neard_versions(
     )
 
 
-@work_with_neard_versions(["1.29.0"])
+@work_with_neard_versions(["1.29.1"])
 def test_maintenance_shutdown(
     kuutamod: Path,
     kuutamoctl: Path,

--- a/tests/test_maintenance_shutdown_metrics.py
+++ b/tests/test_maintenance_shutdown_metrics.py
@@ -51,8 +51,7 @@ def test_maintenance_shutdown_metrics(
         new_pid = leader.neard_pid()
         assert new_pid == pid
 
-        for i in range(3):
-            time.sleep(3)
+        for i in range(90):
             try:
                 res = leader.neard_metrics()
                 if (
@@ -61,7 +60,8 @@ def test_maintenance_shutdown_metrics(
                 ):
                     break
             except ConnectionRefusedError:
-                continue
+                pass
+            time.sleep(0.1)
         else:
             assert (
                 res.get("near_block_expected_shutdown") == "1000"

--- a/tests/test_maintenance_shutdown_metrics.py
+++ b/tests/test_maintenance_shutdown_metrics.py
@@ -52,7 +52,7 @@ def test_maintenance_shutdown_metrics(
         assert new_pid == pid
 
         for i in range(3):
-            time.sleep(1)
+            time.sleep(3)
             try:
                 res = leader.neard_metrics()
                 if (

--- a/tests/test_maintenance_shutdown_metrics.py
+++ b/tests/test_maintenance_shutdown_metrics.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import time
+
+from command import Command
+from consul import Consul
+from kuutamod import Kuutamod
+from note import Section
+from ports import Ports
+from setup_localnet import NearNetwork
+
+
+def test_maintenance_shutdown_metrics(
+    kuutamod: Path,
+    kuutamoctl: Path,
+    command: Command,
+    consul: Consul,
+    near_network: NearNetwork,
+    ports: Ports,
+) -> None:
+    leader = Kuutamod.run(
+        neard_home=near_network.home / "kuutamod0",
+        kuutamod=kuutamod,
+        ports=ports,
+        near_network=near_network,
+        command=command,
+        kuutamoctl=kuutamoctl,
+        consul=consul,
+    )
+
+    with Section("Wait leader validating"):
+        while True:
+            res = leader.metrics()
+            if res.get('kuutamod_state{type="Validating"}') == "1":
+                break
+            time.sleep(1)
+        leader.wait_validator_port()
+
+    # Book a far away block height, so we can check on metric before shutdown
+    with Section("test maintenance shutdown metrics"):
+        pid = leader.neard_pid()
+        assert pid is not None
+
+        proc = leader.execute_command(
+            "maintenance-shutdown",
+            "--shutdown-at",
+            "1000",
+        )
+        assert proc.returncode == 0
+        new_pid = leader.neard_pid()
+        assert new_pid == pid
+
+        for i in range(3):
+            time.sleep(1)
+            try:
+                res = leader.neard_metrics()
+                if (
+                    res.get("near_block_expected_shutdown") == "1000"
+                    and res.get("near_dynamic_config_changes") == "1"
+                ):
+                    break
+            except ConnectionRefusedError:
+                continue
+        else:
+            assert (
+                res.get("near_block_expected_shutdown") == "1000"
+                or res.get("near_dynamic_config_changes") == "1"
+            )

--- a/tests/test_maintenance_shutdown_metrics.py
+++ b/tests/test_maintenance_shutdown_metrics.py
@@ -34,7 +34,7 @@ def test_maintenance_shutdown_metrics(
             res = leader.metrics()
             if res.get('kuutamod_state{type="Validating"}') == "1":
                 break
-            time.sleep(1)
+            time.sleep(0.1)
         leader.wait_validator_port()
 
     # Book a far away block height, so we can check on metric before shutdown


### PR DESCRIPTION
- Fix bug for the Near pid not correct pass to request handler
https://github.com/kuutamolabs/near-staking-knd/blob/main/src/supervisor.rs#L639
- Add testcase for maintenance window related metrics