### PR TITLE
Speedup deployments

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,9 +51,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "nixos-2211": {
@@ -142,16 +141,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673435251,
-        "narHash": "sha256-slcWQtwJBLprSvNODsH/CkpjV7Hx/ByMGkuGmBr65Bw=",
-        "owner": "NixOS",
+        "lastModified": 1674044097,
+        "narHash": "sha256-nMOI9h8hpUVUXbP+9qPMZiwk74/zaxbEwGo4SnQYskA=",
+        "owner": "kuutamolabs",
         "repo": "nixpkgs",
-        "rev": "0abc5480edcab69f26e1bdd5f7ee82890cfe273f",
+        "rev": "dfede1fee334a94c7165652f3a64ff0c0e6a9d1d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "owner": "kuutamolabs",
+        "ref": "kuutamo",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673527444,
-        "narHash": "sha256-lW2ytHc1wqBXRxQC6Tt+EeXqx44MNg06g7iHSfLgGng=",
+        "lastModified": 1673974526,
+        "narHash": "sha256-13aJ6gEIQu6K49w93nCw8gdxUO5EFMCWv8WkLkBLcGs=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "9c71ac0fdc7f0ef2d484c98e315d211286fca5b4",
+        "rev": "298c241ecbd91a60ee1523f9a3353ea6be85b040",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,9 @@
 {
   description = "A supervisor for neard that implements failover for NEAR validators";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+  # Switch back after https://github.com/NixOS/nixpkgs/pull/210382
+  inputs.nixpkgs.url = "github:kuutamolabs/nixpkgs/kuutamo";
+  #inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
 
   inputs.srvos.url = "github:numtide/srvos";
   inputs.srvos.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/modules/neard/default.nix
+++ b/nix/modules/neard/default.nix
@@ -138,7 +138,7 @@ in
                 runNeard ${cfg.package}/bin/neard --home /var/lib/neard init ${lib.optionalString (cfg.chainId != null) "--chain-id=${cfg.chainId}"}
               ''}
               ${lib.optionalString (cfg.s3.dataBackupDirectory != null) ''
-                runNeard aws s3 sync ${lib.optionalString (!cfg.s3.signRequests) "--no-sign-request"} --delete ${cfg.s3.dataBackupDirectory} /var/lib/neard/data
+                runNeard aws s3 sync ${lib.optionalString (!cfg.s3.signRequests) "--no-sign-request"} --delete ${cfg.s3.dataBackupDirectory} /var/lib/neard/data/
               ''}
               ${lib.optionalString (cfg.s3.dataBackupTarball != null) ''
                 runNeard aws s3 --no-sign-request cp ${cfg.s3.dataBackupTarball} /var/lib/neard/data.tar.gz

--- a/nix/modules/single-node-validator/mainnet.nix
+++ b/nix/modules/single-node-validator/mainnet.nix
@@ -4,5 +4,5 @@
     ./default.nix
   ];
   # FIXME: This is hacky because it relies on shell...
-  kuutamo.neard.s3.dataBackupDirectory = "s3://near-protocol-public/backups/mainnet/rpc/$(${pkgs.awscli2}/bin/aws s3 --no-sign-request cp s3://near-protocol-public/backups/mainnet/rpc/latest -)";
+  kuutamo.neard.s3.dataBackupDirectory = "s3://near-protocol-public/backups/mainnet/rpc/$(${pkgs.awscli2}/bin/aws s3 --no-sign-request cp s3://near-protocol-public/backups/mainnet/rpc/latest -)/";
 }

--- a/nix/modules/single-node-validator/testnet.nix
+++ b/nix/modules/single-node-validator/testnet.nix
@@ -4,5 +4,5 @@
     ./default.nix
   ];
   # FIXME: This is hacky because it relies on shell...
-  kuutamo.neard.s3.dataBackupDirectory = "s3://near-protocol-public/backups/testnet/rpc/$(${pkgs.awscli2}/bin/aws s3 --no-sign-request cp s3://near-protocol-public/backups/testnet/rpc/latest -)";
+  kuutamo.neard.s3.dataBackupDirectory = "s3://near-protocol-public/backups/testnet/rpc/$(${pkgs.awscli2}/bin/aws s3 --no-sign-request cp s3://near-protocol-public/backups/testnet/rpc/latest -)/";
 }

--- a/src/deploy/nixos_rebuild.rs
+++ b/src/deploy/nixos_rebuild.rs
@@ -32,6 +32,9 @@ pub fn nixos_rebuild(
         "true",
         "--target-host",
         &target,
+        "--build-host",
+        "",
+        "--use-substitutes",
         "--fast",
     ];
     if action == "rollback" {


### PR DESCRIPTION
There is currently a performance regression where it uploads all
derivations prior to the build, which is slow.
Also now it downloads stuff from the binary cache rather than the builder.