### PR TITLE
enable solana tuning by default

### DIFF
--- a/.github/workflows/build-near-cli.yml
+++ b/.github/workflows/build-near-cli.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
      - main
+     - staging
+     - trying
   pull_request:
 jobs:
   build:

--- a/nix/modules/neard/default.nix
+++ b/nix/modules/neard/default.nix
@@ -18,7 +18,7 @@ in
         We found those to be effective to avoid bottlenecks and missing blocks
         on near validators as well.
       '';
-      default = false;
+      default = true;
     };
     package = lib.mkOption {
       type = lib.types.package;


### PR DESCRIPTION
Potential work around for:

```
Jan 19 21:18:38 validator-00 kuutamod[2353]: thread '<unnamed>' panicked at 'Cannot create memory for a contract call: Region("Cannot allocate memory (os error 12)")', runtime/near-vm-runner/src/wasmer2_runner.rs:587:10
```