### PR TITLE
use fake ssh key

### DIFF
--- a/nix/hosts/flake-module.nix
+++ b/nix/hosts/flake-module.nix
@@ -15,7 +15,7 @@
             kuutamo.network.ipv6.cidr = 48;
 
             users.extraUsers.root.openssh.authorizedKeys.keys = [
-              "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKbBp2dH2X3dcU1zh+xW3ZsdYROKpJd3n13ssOP092qE joerg@turingmachine"
+              "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA snakeoil"
             ];
           };
           validator = {


### PR DESCRIPTION
This nixos configuration is actually never deployed but only used for      
evaluation. But let's use a fake ssh key just in case someone does.        