### PR TITLE
tag hostname on metrics

### DIFF
--- a/example/kneard.toml
+++ b/example/kneard.toml
@@ -46,7 +46,7 @@ public_ssh_keys = ""
 # Ubuntu did not allow `root` login
 # install_ssh_user = "ubuntu"
 
-# Setup ssh host name
+# Setup ssh host name for connection and host label on monitoring dashboard
 # ssh_hostname = ""
 
 # Validator key will use in the validator node
@@ -74,4 +74,5 @@ public_ssh_keys = ""
 
 # The http basic auth password to access self monitoring server
 # self_monitoring_password = ""
+
 

--- a/nix/modules/telegraf.nix
+++ b/nix/modules/telegraf.nix
@@ -12,6 +12,12 @@
       default = false;
       description = "has monitoring setting or not";
     };
+
+    kuutamo.telegraf.hostname = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "the hostname tag on metrics";
+    };
   };
   config = {
     services.telegraf = {
@@ -24,11 +30,18 @@
       extraConfig = {
         agent.interval = "60s";
         inputs = {
-          cpu = { };
+          cpu = {
+            tags = {
+              host = config.kuutamo.telegraf.hostname;
+            };
+          };
           prometheus.urls = [
             "http://localhost:3030/metrics"
             "http://localhost:2233/metrics"
           ];
+          prometheus.tags = {
+            host = config.kuutamo.telegraf.hostname;
+          };
         };
         outputs = {
           http = lib.mkIf config.kuutamo.telegraf.hasMonitoring {

--- a/nix/modules/toml-mapping.nix
+++ b/nix/modules/toml-mapping.nix
@@ -33,6 +33,7 @@ in
     kuutamo.network.ipv6.gateway = cfg.ipv6_gateway or null;
     kuutamo.network.ipv6.cidr = cfg.ipv6_cidr or 128;
 
+    kuutamo.telegraf.hostname = cfg.ssh_hostname;
     kuutamo.telegraf.hasMonitoring = cfg.telegraf_has_monitoring or false;
     kuutamo.telegraf.configHash = cfg.telegraf_config_hash or "";
     kuutamo.exporter.accountId = cfg.validator_account_id or null;

--- a/src/deploy/config.rs
+++ b/src/deploy/config.rs
@@ -175,7 +175,7 @@ struct HostConfig {
     #[toml_example(default = "ubuntu")]
     install_ssh_user: Option<String>,
 
-    /// Setup ssh host name
+    /// Setup ssh host name for connection and host label on monitoring dashboard
     #[serde(default)]
     ssh_hostname: Option<String>,
 


### PR DESCRIPTION
Default host tag is based on `hostname`, add tag in outputs and it can be overwritten by `ssh_hostname`(optional, will take ipv4 address if unset) of `kneard.toml`
```markdown
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Loading config: /var/run/telegraf/config.toml
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Starting Telegraf unknown
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Available plugins: 235 inputs, 9 aggregators, 27 processors, 22 parsers, 57 outputs, 2 secret-stores
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Loaded inputs: cpu disk diskio exec file (2x) kernel_vmstat mdstat mem prometheus smart swap system systemd_units
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Loaded aggregators:
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Loaded processors:
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Loaded secretstores:
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! Loaded outputs: http prometheus_client
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! **Tags enabled: host=validator-00**
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! [agent] Config: Interval:1m0s, Quiet:false, Hostname:"validator-00", Flush Interval:10s
May 17 06:12:42 validator-00 telegraf[2398878]: 2023-05-17T06:12:42Z I! [outputs.prometheus_client] Listening on http://[::]:9273/metrics
May 17 06:13:00 validator-00 telegraf[2398878]: 2023-05-17T06:13:00Z E! [agent] Error writing to outputs.http: when writing to [https://mimir.monitoring-00-cluster.kuutamo.computer/api/v1/push] received status code: 400. body: failed pushing to ingester: user=near-testnet-645a0581ffd192fd34e92a96: the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 2023-05-17T06:13:00Z and is from series {__name__="near_peer_msg_size_bytes_count", addr="54.149.171.195:29838", host="141.95.84.70", url="http://localhost:3030/metrics"}
May 17 06:13:02 validator-00 telegraf[2398878]: 2023-05-17T06:13:02Z E! [agent] Error writing to outputs.http: when writing to [https://mimir.monitoring-00-cluster.kuutamo.computer/api/v1/push] received status code: 400. body: failed pushing to ingester: user=near-testnet-645a0581ffd192fd34e92a96: the sample has been rejected because another sample with the same timestamp, but a different value, has already been ingested (err-mimir-sample-duplicate-timestamp). The affected sample has timestamp 2023-05-17T06:13:00Z and is from series {__name__="near_peer_msg_size_bytes_sum", addr="54.149.171.195:29838", **host="141.95.84.70"**, url="http://localhost:3030/metrics"}

```