### PR TITLE
analytics: add optional daily local backup

### DIFF
--- a/nix/modules/single-node-archiver/default.nix
+++ b/nix/modules/single-node-archiver/default.nix
@@ -10,6 +10,9 @@
   kuutamo.disko.disks = lib.mkDefault [ "/dev/nvme0n1" "/dev/nvme1n1" "/dev/nvme2n1" "/dev/nvme0n1" ];
 
   services.mongodb.enable = true;
-  kuutamo.near-staking-analytics.enable = true;
+  kuutamo.near-staking-analytics = {
+    enable = true;
+    backupLocation = "/root/backup";
+  };
   networking.firewall.allowedTCPPorts = [ 8080 ];
 }


### PR DESCRIPTION
This backups locally for now, we can later add remote S3 support or similiar.